### PR TITLE
Support config DB only

### DIFF
--- a/constance/settings.py
+++ b/constance/settings.py
@@ -8,6 +8,8 @@ BACKEND = getattr(
 
 CONFIG = getattr(settings, 'CONSTANCE_CONFIG', {})
 
+CONFIG_ONLY = getattr(settings, 'CONSTANCE_CONFIG_ONLY_DB', {})
+
 CONFIG_FIELDSETS = getattr(settings, 'CONSTANCE_CONFIG_FIELDSETS', {})
 
 ADDITIONAL_FIELDS = getattr(settings, 'CONSTANCE_ADDITIONAL_FIELDS', {})


### PR DESCRIPTION
Parameter CONSTANCE_CONFIG_ONLY_DB was added.
This parameter is holding your variables in database via Constance DB, without display this values in admin panel.

for using Constance DB without adding this parameters in user interface.

EXAMPLE FOR USING:

In settings:
CONSTANCE_CONFIG_ONLY_DB = {
'YOUR_SETTINGS_TYPE': ('0', u'Description of settings', str),
'YOUR_SETTINGS_TEXT': ('your text', u'Description of setting', str)
}

In your code:
get value:
config.YOUR_SETTINGS_TYPE

set value:
config.YOUR_SETTINGS_TYPE = '2'